### PR TITLE
Dev underenheter

### DIFF
--- a/.github/workflows/deploy-dev-underenheter.yml
+++ b/.github/workflows/deploy-dev-underenheter.yml
@@ -4,7 +4,7 @@ on:
     paths:
       - dev-underenheter/**
     branches:
-      - dev-underenheter
+      - master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev-underenheter.yml
+++ b/.github/workflows/deploy-dev-underenheter.yml
@@ -1,0 +1,30 @@
+name: deploy-dev-underenheter
+on:
+  push:
+    paths:
+      - dev-underenheter/**
+    branches:
+      - dev-underenheter
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: build and push image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd dev-underenheter
+          VTAG=$(TZ=Europe/Oslo date +"%y.%j.%H%M%S")
+          IMAGE=docker.pkg.github.com/$GITHUB_REPOSITORY/dev-underenheter:$VTAG
+          docker build . --pull -t "$IMAGE"
+          echo "$GITHUB_TOKEN" | docker login docker.pkg.github.com --username "$GITHUB_REPOSITORY" --password-stdin
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+          echo $IMAGE
+      - name: deploy naisjob to dev-gcp
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: dev-underenheter/naisjob.yml

--- a/dev-underenheter/Dockerfile
+++ b/dev-underenheter/Dockerfile
@@ -1,0 +1,10 @@
+FROM bash:5
+
+RUN apk add --no-cache curl
+RUN apk add --no-cache jq
+
+COPY data/*.json /data/
+
+COPY job.sh /job.sh
+RUN chmod +x /job.sh
+ENTRYPOINT ["/job.sh"]

--- a/dev-underenheter/README.md
+++ b/dev-underenheter/README.md
@@ -1,0 +1,16 @@
+# Insert Altinn test companies for dev-gcp environment in underenhet index
+
+Some Altinn company orgnrs that we use in our testing environment are not
+available in production data downloaded from brreg.no. This is a Kubernetes job
+which we can run on dev-gcp to add some of the test companies to underenhet
+index in Elastic Search stilling cluster periodically.
+
+Test companies are located as ES stilling underenhet formatted index documents,
+one JSON file per orgnr, under `data/*.json`.
+
+## Deploying naisjob
+
+It is built and automatically deployed to dev-gcp whenever changes are pushed to
+content under this directory or any subdirectory. This job shall never run in
+the production environment.
+

--- a/dev-underenheter/data/010005434.json
+++ b/dev-underenheter/data/010005434.json
@@ -1,0 +1,22 @@
+{
+  "naringskoder": [
+    {
+      "beskrivelse": "Hav- og kystfiske",
+      "kode": "03.111"
+    }
+  ],
+  "adresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "kommune": "KRISTIANSAND",
+    "kommunenummer": "4204",
+    "poststed": "Brennåsen",
+    "postnummer": "4647",
+    "adresse": "Rosselandsvegen 6"
+  },
+  "antallAnsatte": 20,
+  "organisasjonsform": "BEDR",
+  "navn": "STOLMEN OG BRENNÅSEN",
+  "organisasjonsnummer": "010005434",
+  "overordnetEnhet": "0"
+}

--- a/dev-underenheter/data/811057312.json
+++ b/dev-underenheter/data/811057312.json
@@ -1,0 +1,22 @@
+{
+  "naringskoder": [
+    {
+      "beskrivelse": "Bygging av vann- og kloakk-anlegg",
+      "kode": "42.210"
+    }
+  ],
+  "adresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "kommune": "INDRE ØSTFOLD KOMMUNE",
+    "kommunenummer": "3014",
+    "poststed": "Spydeberg",
+    "postnummer": "1820",
+    "adresse": "Wilses Vei 3"
+  },
+  "antallAnsatte": 10,
+  "organisasjonsform": "BEDR",
+  "navn": "AUSTBØ OG KNAPPSTAD",
+  "organisasjonsnummer": "811057312",
+  "overordnetEnhet": "0"
+}

--- a/dev-underenheter/data/910559451.json
+++ b/dev-underenheter/data/910559451.json
@@ -1,0 +1,22 @@
+{
+  "naringskoder": [
+    {
+      "beskrivelse": "Hav- og kystfiske",
+      "kode": "03.111"
+    }
+  ],
+  "adresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "kommune": "VOSS",
+    "kommunenummer": "4621",
+    "poststed": "Vossevangen",
+    "postnummer": "5709",
+    "adresse": "Vosselandsvegen 6"
+  },
+  "antallAnsatte": 56,
+  "organisasjonsform": "BEDR",
+  "navn": "RØST OG VOSS",
+  "organisasjonsnummer": "910559451",
+  "overordnetEnhet": "0"
+}

--- a/dev-underenheter/job.sh
+++ b/dev-underenheter/job.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Setup logging as JSON
+exec 100>&1 200>&2
+coproc JSON_LOGGER { jq --unbuffered -Rc '{"@timestamp": now|strftime("%Y-%m-%dT%H:%M:%S%z"),
+                                           "message":.}' 1>&100 2>&200; }
+exec 1>&${JSON_LOGGER[1]} 2>&${JSON_LOGGER[1]}
+# End setup JSON logging
+
+# Shutdown linkerd on exit, to ensure clean and timely pod shutdown
+trap 'echo Shutdown linkerd: "$(curl -sS -XPOST http://127.0.0.1:4191/shutdown 2>&1)"' EXIT
+
+echo 'Waiting 10 seconds for linkerd ..'
+sleep 10
+
+for doc in /data/*.json; do
+    orgnr=$(basename $doc .json)
+    curl -sS -u "$ES_USER:$ES_PASSWORD" -XPUT -H 'Content-type: application/json' --data-binary @"$doc" "$ES_STILLING_BACKEND/underenhet/_doc/$orgnr"
+    echo
+    echo "Indexed dev-underenhet $orgnr"
+done
+
+sleep 1
+echo Finished.

--- a/dev-underenheter/naisjob.yml
+++ b/dev-underenheter/naisjob.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: teampam
 spec:
   image: {{ image }}
-  schedule: "30 3 * * *"
+  schedule: "30 2 * * *" # GMT
   activeDeadlineSeconds: 60
 
   env:

--- a/dev-underenheter/naisjob.yml
+++ b/dev-underenheter/naisjob.yml
@@ -1,0 +1,24 @@
+apiVersion: nais.io/v1
+kind: Naisjob
+metadata:
+  labels:
+    team: teampam
+  name: pam-er-sync-dev-underenheter
+  namespace: teampam
+spec:
+  image: {{ image }}
+  schedule: "30 3 * * *"
+  activeDeadlineSeconds: 60
+
+  env:
+    - name: ES_STILLING_BACKEND
+      value: https://stillinger-opendistro-elasticsearch.dev.intern.nav.no
+  envFrom:
+    - secret: pam-er-sync-dev-underenheter-env
+
+  accessPolicy:
+    outbound:
+      rules:
+        - application: stillinger-opendistro-elasticsearch
+      external:
+        - host: stillinger-opendistro-elasticsearch.dev.intern.nav.no


### PR DESCRIPTION
    [PAM-5157] Add naisjob which indexes test companies to ES-stilling in dev-gcp

    * Index additional companies that only exist in our testing environment, into brreg index.
    Run every night after main pam-er-sync scheduled brreg index creation has occured.

    * Deploys a naisjob to dev-gcp only, which runs on a schedule. Trigger new deploy
    on push to code under dev-undereheter/** in this repository.

    * New test companies can be added as ES JSON documents under dev-underenheter/data/<orgnr>.json.


Foreløpig går jobben mot ingress-adressen til ES, da jeg ikke har helt klart for meg hvordan jeg oppdaterer `accessPolicy` for ES-stilling.

https://jira.adeo.no/browse/PAM-5157