### PR TITLE
Publiser docker-image kun til GAR

### DIFF
--- a/.github/workflows/deploy-dev-underenheter.yml
+++ b/.github/workflows/deploy-dev-underenheter.yml
@@ -9,26 +9,18 @@ on:
       - feature/**
 jobs:
   build-and-deploy:
+    uses: navikt/pam-deploy/.github/workflows/deploy-dev.yml@v7
     permissions:
-      packages: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: build and push image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd dev-underenheter
-          VTAG=$(TZ=Europe/Oslo date +"%y.%j.%H%M%S")
-          IMAGE=docker.pkg.github.com/$GITHUB_REPOSITORY/dev-underenheter:$VTAG
-          docker build . --pull -t "$IMAGE"
-          echo "$GITHUB_TOKEN" | docker login docker.pkg.github.com --username "$GITHUB_REPOSITORY" --password-stdin
-          docker push "$IMAGE"
-          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
-          echo $IMAGE
-      - name: deploy naisjob to dev-gcp
-        uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: dev-underenheter/naisjob.yml
+      actions: read
+      contents: write
+      security-events: write
+      id-token: write
+    with:
+      CODEQL_ENABLED: false
+      SKIP_DRAFT_RELEASE: ${{ github.ref_name != 'master' }}
+      WORKING_DIRECTORY: "./dev-underenheter/"
+      IMAGE_SUFFIX: "dev-underenheter"
+      NAIS_RESOURCE: "./dev-underenheter/naisjob.yml"
+      LANGUAGE: "bash"
+    secrets:
+      NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}

--- a/dev-underenheter/Dockerfile
+++ b/dev-underenheter/Dockerfile
@@ -3,8 +3,8 @@ FROM bash:5
 RUN apk add --no-cache curl
 RUN apk add --no-cache jq
 
-COPY data/*.json /data/
+COPY dev-underenheter/data/*.json /data/
 
-COPY job.sh /job.sh
+COPY dev-underenheter/job.sh /job.sh
 RUN chmod +x /job.sh
 ENTRYPOINT ["/job.sh"]

--- a/dev-underenheter/build.sh
+++ b/dev-underenheter/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-echo "Nothing to build, the docker image is built in the deploy step"
+echo "Trenger ikke å gjøre noe. Denne fila kreves bare av pam-deploy, og pam-deloy tar seg av å bygge docker-image-et."

--- a/dev-underenheter/build.sh
+++ b/dev-underenheter/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+echo "Nothing to build, the docker image is built in the deploy step"

--- a/dev-underenheter/naisjob.yml
+++ b/dev-underenheter/naisjob.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: teampam
 spec:
   image: {{ image }}
-  schedule: "* 7 * * *" # GMT
+  schedule: "0 7 * * *" # GMT
   activeDeadlineSeconds: 60
 
   env:


### PR DESCRIPTION
Tar i bruk `pam-deploy` også for deploy av `dev-underenheter` som kun skal brukes i `dev`.